### PR TITLE
GHC 8.0 compat

### DIFF
--- a/logging-effect.cabal
+++ b/logging-effect.cabal
@@ -1,5 +1,5 @@
 name: logging-effect
-version: 1.1.0
+version: 1.2.0
 synopsis: A mtl-style monad transformer for general purpose & compositional logging
 homepage: https://github.com/ocharles/logging-effect
 license: BSD3
@@ -13,11 +13,11 @@ extra-source-files: Changelog.md
 library
   exposed-modules:     Control.Monad.Log
   other-extensions:    ViewPatterns, OverloadedStrings, GeneralizedNewtypeDeriving, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, FunctionalDependencies, PatternSynonyms
-  build-depends:       base >=4.8 && <4.9
-                     , async >=2.0 && <2.1
-                     , transformers >=0.4 && <0.5
+  build-depends:       base >=4.8 && <4.10
+                     , async >=2.0 && <2.2
+                     , transformers >=0.4 && <0.6
                      , text >=1.2 && <1.3
-                     , time >=1.5 && <1.6
+                     , time >=1.5 && <1.7
                      , mtl >= 2.2.1 && <2.3
                      , exceptions >= 0.8.0.2 && <0.9
                      , free >= 4.12.1 && < 4.13


### PR DESCRIPTION
Backwards incompatible changes in GHC API unfortunately require `CPP` to handle.

`GHC.SrcLoc` was removed and some of it moved to `GHC.Stack`

`GHC.Stack` is now imported with explicit name list to solve conflict with prettyCallStack function. And it is a good thing to do with unstable GHC API in general.

`WithCallstack` lost `Eq` instance because `CallStack` also lost it in ghc-8.0 and this change requires major version bump.

tested with 8.0.1 and 7.10.3
