### PR TITLE
Support GHC 8.0

### DIFF
--- a/logging-effect.cabal
+++ b/logging-effect.cabal
@@ -13,11 +13,11 @@ extra-source-files: Changelog.md
 library
   exposed-modules:     Control.Monad.Log
   other-extensions:    ViewPatterns, OverloadedStrings, GeneralizedNewtypeDeriving, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, FunctionalDependencies, PatternSynonyms
-  build-depends:       base >=4.8 && <4.9
-                     , async >=2.0 && <2.1
-                     , transformers >=0.4 && <0.5
+  build-depends:       base >=4.8 && <5.0
+                     , async >=2.0 && <2.2
+                     , transformers >=0.4 && <0.6
                      , text >=1.2 && <1.3
-                     , time >=1.5 && <1.6
+                     , time >=1.5 && <1.7
                      , mtl >= 2.2.1 && <2.3
                      , exceptions >= 0.8.0.2 && <0.9
                      , free >= 4.12.1 && < 4.13


### PR DESCRIPTION
Hi Ollie,

Thanks for showing me logging-effect at Haskell eXchange. I tried it out, but found it didn't support GHC 8.0. Here's a patch that tries to make it do so.

Only behaviour impact (I think) is that `WithCallStack` no longer supports `Eq`. 

My philosophy was to produce a minimal viable diff. I see there's code in `Log.hs` that very closely mirrors new GHC 8.0 stuff, but I figure that can be refactored later without dropping support, and would probably be better done by someone who understood the original intent.

Thanks,
jml
