### PR TITLE
Remove unused ViewPatterns extension

### DIFF
--- a/src/Control/Monad/Log.hs
+++ b/src/Control/Monad/Log.hs
@@ -16,7 +16,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Control.Monad.Log
        ( -- * Introduction
@@ -801,7 +800,7 @@ main :: IO ()
 main = do
   'withFDHandler' 'defaultBatchingOptions' 'stderr' 0.4 80 $ \\stderrHandler ->
   'withFDHandler' 'defaultBatchingOptions' 'stdout' 0.4 80 $ \\stdoutHandler ->
-  'runLoggingT' m
+  'runLoggingT' testApp
               (\\message ->
                  case 'msgSeverity' message of
                    'Error' -> stderrHandler ('discardSeverity' message)


### PR DESCRIPTION
Thanks for the super nice lib!  👏 👏 👏 

The `other-extensions` in the .cabal file weren't needed since `Control.Monad.Log` explicitly lists the ones it uses.  Removed `ViewPatterns` altogether since it wasn't used.

Snuck a docs update in this PR too so that the relevant `runLoggingT` examples all refer to `testApp`.