### PR TITLE
Dependency bumps; support ghc 9.6

### DIFF
--- a/logging-effect.cabal
+++ b/logging-effect.cabal
@@ -15,10 +15,10 @@ library
   other-extensions:    ViewPatterns, OverloadedStrings, GeneralizedNewtypeDeriving, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, FunctionalDependencies, PatternSynonyms
   build-depends:       base >=4.8 && <4.18
                      , async >=2.0 && <2.3
-                     , transformers >=0.4 && <0.6
+                     , transformers >=0.4 && <0.7
                      , text >=1.2 && <2.0.2
                      , time >=1.5 && <1.13
-                     , mtl >= 2.2.1 && <2.3
+                     , mtl >= 2.2.1 && <2.4
                      , exceptions >= 0.8.0.2 && <0.11
                      , free >= 4.12.1 && < 5.2
                      , stm >= 2.4.4.1 && < 2.6

--- a/logging-effect.cabal
+++ b/logging-effect.cabal
@@ -13,10 +13,10 @@ extra-source-files: Changelog.md
 library
   exposed-modules:     Control.Monad.Log
   other-extensions:    ViewPatterns, OverloadedStrings, GeneralizedNewtypeDeriving, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, FunctionalDependencies, PatternSynonyms
-  build-depends:       base >=4.8 && <4.17
+  build-depends:       base >=4.8 && <4.18
                      , async >=2.0 && <2.3
                      , transformers >=0.4 && <0.6
-                     , text >=1.2 && <1.3
+                     , text >=1.2 && <2.0.2
                      , time >=1.5 && <1.13
                      , mtl >= 2.2.1 && <2.3
                      , exceptions >= 0.8.0.2 && <0.11

--- a/logging-effect.cabal
+++ b/logging-effect.cabal
@@ -16,7 +16,7 @@ library
   build-depends:       base >=4.8 && <4.18
                      , async >=2.0 && <2.3
                      , transformers >=0.4 && <0.7
-                     , text >=1.2 && <2.0.2
+                     , text >=1.2 && <2.0.3
                      , time >=1.5 && <1.13
                      , mtl >= 2.2.1 && <2.4
                      , exceptions >= 0.8.0.2 && <0.11

--- a/logging-effect.cabal
+++ b/logging-effect.cabal
@@ -13,7 +13,7 @@ extra-source-files: Changelog.md
 library
   exposed-modules:     Control.Monad.Log
   other-extensions:    ViewPatterns, OverloadedStrings, GeneralizedNewtypeDeriving, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, FunctionalDependencies, PatternSynonyms
-  build-depends:       base >=4.8 && <4.18
+  build-depends:       base >=4.8 && <4.19
                      , async >=2.0 && <2.3
                      , transformers >=0.4 && <0.7
                      , text >=1.2 && <2.0.3

--- a/src/Control/Monad/Log.hs
+++ b/src/Control/Monad/Log.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE AutoDeriveTypeable #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -13,7 +11,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -83,7 +80,7 @@ import Control.Monad.Error.Class (MonadError(..))
 import Control.Monad.Fix
 import Control.Monad.Free.Class (MonadFree(..))
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.IO.Unlift (MonadUnliftIO(..), UnliftIO(..), withUnliftIO)
+import Control.Monad.IO.Unlift (MonadUnliftIO(..))
 import Control.Monad.RWS.Class (MonadRWS)
 import Control.Monad.Reader.Class (MonadReader(..))
 import Control.Monad.State.Class (MonadState(..))
@@ -92,7 +89,6 @@ import Control.Monad.Trans.Control
 import Control.Monad.Trans.Reader (ReaderT(..))
 import Control.Monad.Trans.State.Strict (StateT(..))
 import Control.Monad.Writer.Class (MonadWriter(..))
-import Data.Semigroup ((<>))
 import Data.Time (UTCTime, getCurrentTime)
 #if MIN_VERSION_base(4,9,0)
 import qualified Control.Monad.Fail as Fail
@@ -105,8 +101,8 @@ import GHC.Stack (SrcLoc, CallStack, getCallStack, prettySrcLoc)
 #endif
 import System.IO (Handle, hFlush)
 import qualified Data.Text.Lazy as LT
-import qualified Data.Text.Prettyprint.Doc as PP
-import qualified Data.Text.Prettyprint.Doc.Render.Text as PP
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PP
 import qualified Data.List.NonEmpty as NEL
 
 -- For 'MonadLog' pass-through instances.
@@ -118,7 +114,6 @@ import qualified Control.Monad.Trans.Writer.Lazy as LazyWriter
 import qualified Control.Monad.Trans.Writer.Strict as StrictWriter
 import qualified Control.Monad.Trans.Maybe as Maybe
 import qualified Control.Monad.Trans.Except as Except
-import qualified Control.Monad.Trans.Error as Error
 import qualified Control.Monad.Trans.RWS.Lazy as LazyRWS
 import qualified Control.Monad.Trans.RWS.Strict as StrictRWS
 import qualified Control.Monad.Trans.Cont as Cont
@@ -185,7 +180,6 @@ instance (Monoid w, MonadLog message m) => MonadLog message (StrictWriter.Writer
 instance (Monoid w, MonadLog message m) => MonadLog message (LazyWriter.WriterT w m)
 instance MonadLog message m => MonadLog message (Maybe.MaybeT m)
 instance MonadLog message m => MonadLog message (Except.ExceptT e m)
-instance (Error.Error e, MonadLog message m) => MonadLog message (Error.ErrorT e m)
 instance (Monoid w, MonadLog message m) => MonadLog message (StrictRWS.RWST r w s m)
 instance (Monoid w, MonadLog message m) => MonadLog message (LazyRWS.RWST r w s m)
 instance MonadLog message m => MonadLog message (Cont.ContT r m)

--- a/src/Control/Monad/Log.hs
+++ b/src/Control/Monad/Log.hs
@@ -117,7 +117,6 @@ import qualified Control.Monad.Trans.Except as Except
 import qualified Control.Monad.Trans.RWS.Lazy as LazyRWS
 import qualified Control.Monad.Trans.RWS.Strict as StrictRWS
 import qualified Control.Monad.Trans.Cont as Cont
-import qualified Control.Monad.Trans.List as List
 import qualified Control.Monad.Trans.Free as Free
 import qualified Control.Monad.Trans.Free.Church as Free
 import qualified Control.Monad.Catch.Pure as Exceptions
@@ -183,7 +182,6 @@ instance MonadLog message m => MonadLog message (Except.ExceptT e m)
 instance (Monoid w, MonadLog message m) => MonadLog message (StrictRWS.RWST r w s m)
 instance (Monoid w, MonadLog message m) => MonadLog message (LazyRWS.RWST r w s m)
 instance MonadLog message m => MonadLog message (Cont.ContT r m)
-instance MonadLog message m => MonadLog message (List.ListT m)
 instance (Functor f, MonadLog message m) => MonadLog message (Free.FreeT f m)
 instance (Functor f, MonadLog message m) => MonadLog message (Free.FT f m)
 instance MonadLog message m => MonadLog message (Exceptions.CatchT m)


### PR DESCRIPTION
Note that
- this is based off #36, which supports ghc 9.4
- these changes probably need a changelog entry
- the removal of an instance for `ListT` may need a version bump for `logging-effect` (I'm unsure on this point)

Happy to change the patch for these last two points, but not sure what policy is here.

Fixes #37 